### PR TITLE
Syntax highlight for dub SDLang and dmd coverage (.lst).

### DIFF
--- a/ftdetect/dcov.vim
+++ b/ftdetect/dcov.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.lst set filetype=dcov

--- a/ftdetect/dsdl.vim
+++ b/ftdetect/dsdl.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.sdl set filetype=dsdl

--- a/syntax/dcov.vim
+++ b/syntax/dcov.vim
@@ -1,0 +1,51 @@
+" Vim syntax file for coverage information for the reference compiler (DMD) of
+" the D programming language.
+"
+" Language:     dcov (dlang coverage testing output)
+" Maintainer:   Jesse Phillips <Jesse.K.Phillips+D@gmail.com>
+" Last Change:  2015-07-10
+"
+" Contributors:
+"   - Joakim Brannstrom <joakim.brannstrom@gmx.com>
+"
+" Please submit bugs/comments/suggestions to the github repo:
+" https://github.com/JesseKPhillips/d.vim
+
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" Provide highlight of D code.
+runtime! syntax/d.vim
+unlet b:current_syntax
+
+" Source lines
+syn match dcovCode              "^\s*|"
+syn match dcovExecuted          "^\s*\d\+|"
+syn match dcovNotExecuted       "^\s*0\+|"
+
+" Coverage statistic
+" 0% is critical
+" 1-39% is low
+" 40-99 is partial
+" 100% is complete
+syn match dcovFile              contained "^.\{-}\s\+\( is \)\@!"
+syn match dcovPartial           contained "\d\+% cov\w*"
+syn match dcovFull              contained "100% cov\w*"
+syn match dcovLow               contained "[1-3]\=\d\=% cov\w*"
+syn match dcovNone              contained "0% cov\w*"
+syn match dcovStat              "^\(.\{0,7}|\)\@!.*$" contains=dcovFull,dcovPartial,dcovNone,dcovFile,dcovLow
+
+" Define the default highlighting.
+" Only used when an item doesn't have highlighting yet
+hi def link dcovNotExecuted             Constant
+hi def link dcovExecuted                Type
+hi def link dcovCode                    Comment
+hi def link dcovFull                    PreProc
+hi def link dcovFile                    Identifier
+hi def link dcovNone                    Error
+hi def link dcovLow                     Operator
+hi def link dcovPartial                 Structure
+
+let b:current_syntax = "dcov"

--- a/syntax/dsdl.vim
+++ b/syntax/dsdl.vim
@@ -1,0 +1,90 @@
+" Vim syntax file for DUB configurations."
+"
+" Language:     SDLang (dub config)
+" Maintainer:   Jesse Phillips <Jesse.K.Phillips+D@gmail.com>
+" Last Change:  2015-07-11
+"
+" Contributors:
+"   - Joakim Brannstrom <joakim.brannstrom@gmx.com>
+"
+" Please submit bugs/comments/suggestions to the github repo:
+" https://github.com/JesseKPhillips/d.vim
+
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" General matchers
+syn match dsdlAssign         contained "="
+syn match dsdlAttribute      "\w*\s*=" contains=dsdlAssign
+syn match dsdlStatement      "^\s*[a-zA-Z:]*"
+
+" Keyword grouping
+syn keyword dsdlInfo         name description copyright authors license
+syn keyword dsdlStructure    buildRequirements buildType configuration
+syn keyword dsdlBoolean      true false on off
+
+syn keyword dsdlTodo         contained TODO FIXME XXX
+
+" dsdlCommentGroup allows adding matches for special things in comments
+syn cluster dsdlCommentGroup   contains=dsdlTodo
+
+" Highlight % items in strings.
+syn match   dsdlFormat     display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlL]\|ll\)\=\([bdiuoxXDOUfeEgGcCsSpn]\|\[\^\=.[^]]*\]\)" contained
+
+" dsdlCppString: same as dsdlString, but ends at end of line
+syn region  dsdlString     start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,dsdlFormat,@Spell extend
+syn region  dsdlCppString  start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,dsdlFormat,@Spell
+
+syn cluster dsdlStringGroup    contains=dsdlCppString
+
+" Comments
+syn region  dsdlCommentL   start="//" skip="\\$" end="$" keepend contains=@dsdlCommentGroup,cSpaceError,@Spell
+syn region  dsdlComment    matchgroup=cCommentStart start="/\*" end="\*/" contains=@dsdlCommentGroup,dsdlCommentStartError,cSpaceError,@Spell fold extend
+" keep a // comment separately, it terminates a preproc. conditional
+syn match   dsdlCommentError       display "\*/"
+syn match   dsdlCommentStartError  display "/\*"me=e-1 contained
+
+"integer number, or floating point number without a dot and with "f".
+syn case ignore
+syn match   dsdlNumbers    display transparent "\<\d\|\.\d" contains=dsdlNumber,dsdlFloat,cOctalError,dsdlOctal
+" Same, but without octal error (for comments)
+syn match   dsdlNumbersCom display contained transparent "\<\d\|\.\d" contains=dsdlNumber,dsdlFloat,dsdlOctal
+syn match   dsdlNumber     display contained "\d\+\(u\=l\{0,2}\|ll\=u\)\>"
+"hex number
+syn match   dsdlNumber     display contained "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
+" Flag the first zero of an octal number as something special
+syn match   dsdlOctal      display contained "0\o\+\(u\=l\{0,2}\|ll\=u\)\>" contains=dsdlOctalZero
+syn match   dsdlOctalZero  display contained "\<0"
+syn match   dsdlFloat      display contained "\d\+f"
+"floating point number, with dot, optional exponent
+syn match   dsdlFloat      display contained "\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\="
+"floating point number, starting with a dot, optional exponent
+syn match   dsdlFloat      display contained "\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
+"floating point number, without dot, with exponent
+syn match   dsdlFloat      display contained "\d\+e[-+]\=\d\+[fl]\=\>"
+syn case match
+
+" Define the default highlighting.
+" Only used when an item doesn't have highlighting yet
+hi def link dsdlInfo                 Constant
+hi def link dsdlAssign               Special
+hi def link dsdlBoolean              Boolean
+hi def link dsdlFormat               SpecialChar
+hi def link dsdlCppString            dsdlString
+hi def link dsdlCommentL             dsdlComment
+hi def link dsdlNumber               Number
+hi def link dsdlOctal                Number
+hi def link dsdlOctalZero            PreProc  " link this to Error if you want
+hi def link dsdlFloat                Float
+hi def link dsdlCommentError         Error
+hi def link dsdlCommentStartError    Error
+hi def link dsdlStructure            Structure
+hi def link dsdlString               String
+hi def link dsdlComment              Comment
+hi def link dsdlTodo                 Todo
+hi def link dsdlStatement            Statement
+hi def link dsdlAttribute            Tag
+
+let b:current_syntax = "dsdl"

--- a/tests/coverage.lst
+++ b/tests/coverage.lst
@@ -1,0 +1,48 @@
+       |/// Written in the D programming language.
+       |/// Date: 2014-2015, Joakim Brännström
+       |module app_main;
+       |
+       |import std.conv;
+       |import logger = std.experimental.logger;
+       |
+       |void fun(int y) {
+0000000|    int x;
+0000000|    writeln(x+y);
+       |}
+       |
+       |class SimpleLogger : logger.Logger {
+       |    int line = -1;
+       |    string file = null;
+       |    string func = null;
+       |    string prettyFunc = null;
+       |    string msg = null;
+       |    logger.LogLevel lvl;
+       |
+      1|    this(const logger.LogLevel lv = logger.LogLevel.info) {
+      1|        super(lv);
+       |    }
+       |
+       |    override void writeLogMsg(ref LogEntry payload) @trusted {
+      2|        this.line = payload.line;
+      2|        this.file = payload.file;
+      2|        this.func = payload.funcName;
+      2|        this.prettyFunc = payload.prettyFuncName;
+      2|        this.lvl = payload.logLevel;
+      2|        this.msg = payload.msg;
+       |
+      2|        stderr.writefln("%s: %s", text(this.lvl), this.msg);
+       |    }
+       |}
+       |
+       |void rmain(string[] args) nothrow {
+      1|    auto simple_logger = new SimpleLogger();
+      1|    logger.sharedLog(simple_logger);
+      1|    logger.info("fun");
+      1|    logger.info("fun");
+       |}
+source/app_main.d is 0% covered
+source/app_main.d is 1% covered
+source/app_main.d is 39% covered
+source/app_main.d is 40% covered
+source/app_main.d is 99% covered
+source/app_main.d is 100% covered

--- a/tests/dub.sdl
+++ b/tests/dub.sdl
@@ -1,0 +1,37 @@
+name "test-some-name"
+description "Demo syntax highlight of DUB configuration"
+copyright "Copyright © 2015, Joakim Brännström"
+authors "Joakim Brännström"
+license "BSL"
+
+dependency "tested" version="~>0.9.4"
+dependency "docopt" version="~>0.6.1-b.3"
+dependency "dsrcgen" path="dsrcgen"
+
+targetPath "build"
+mainSourceFile "source/app.d"
+sourcePaths "source" "clang"
+importPaths "source" "clang"
+stringImportPaths "clang/resources"
+excludedSourceFiles "source/wip_main.d" "source/analyze"
+lflags "-lclang" "-rpath" "." "-L." "$LFLAGS"
+
+buildRequirements {
+    "requireBoundsCheck"
+    "requireContracts"
+}
+
+buildType "unittest-cov" {
+    buildOptions "unittests" "debugMode" "debugInfo" "coverage"
+}
+
+configuration "release" {
+    targetType "executable"
+    excludedSourceFiles "source/wip_main.d" "source/generator/analyze"
+}
+
+configuration "unittest" {
+    targetName "unittest"
+    targetType "executable"
+    buildType "debugInfo"
+}


### PR DESCRIPTION
This is my first syntax highlighting for VIM. Sorry for any stupid mistakes.
To make the colors work with different color schema I chose to reuse existing colors.

Coverage
Combines the syntax HL for D with the coverage statistics from DMD. It is now pleasant to read the coverage file.
The last line is separately handled to provide "eye catching" HL indicate coverage completeness.

SDLang
The highlighting for SDLang is mostly derived from c.vim. I chose to mark the package information with a different color from the "functional".
I also tried to use the structural support for keywords that are "blocks" like configuration.