### PR TITLE
Keep multiline array literals at same indent.

### DIFF
--- a/indent/d.vim
+++ b/indent/d.vim
@@ -65,5 +65,13 @@ function GetDIndent()
     return cindent(lnum - 1)
   endif
 
+  " Align multiline array literals. e.g.:
+  " auto a = [
+  "   [ 1, 2, 3 ],
+  "   [ 4, 5, 6 ],
+  if line =~ '^\s*\[' && getline(lnum - 1) =~ '^\s*\['
+    return indent(lnum - 1)
+  endif
+
   return cind
 endfunction

--- a/tests/array.d
+++ b/tests/array.d
@@ -1,0 +1,10 @@
+// Nothing should change when you reindent (press =G from the top)
+
+unittest {
+  auto a = [
+    [ 1, 2, 3, 4 ],
+    [ 1, 2, 3, 4 ],
+    [ 1, 2, 3, 4 ],
+    [ 1, 2, 3, 4 ],
+  ];
+}


### PR DESCRIPTION
This doesn't fix all issues with multiline arrays, but at least fixes this simple case:

If the current line and the line above both begin with an array literal, align
the current line with the above line.
Resolves #26.

Keeps multiline 2D array definitions aligned like so:
auto a = [
  [1, 2, 3],
  [1, 2, 3],
  [1, 2, 3],
];

Previously they were aligned like so:
auto a = [
  [1, 2, 3],
  [1, 2, 3],
    [1, 2, 3],
];