### PR TITLE
Add some Ddoc highlighting.

### DIFF
--- a/ftdetect/ddoc.vim
+++ b/ftdetect/ddoc.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.ddoc set filetype=ddoc

--- a/syntax/d.vim
+++ b/syntax/d.vim
@@ -16,6 +16,9 @@
 "
 "   d_hl_object_types - Set to highlight some common types from object.di.
 
+"load the ddoc syntax
+runtime! /syntax/ddoc.vim
+
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
   finish
@@ -27,39 +30,6 @@ set cpo&vim
 
 " Set the current syntax to be known as d
 let b:current_syntax = "d"
-
-"Ddoc 
-if getline(1) =~ "^Ddoc"
-    "Ddoc File
-    syn match ddocKeyword       "\%^Ddoc"               display
-    syn keyword ddocKeyword     MACROS                  contained
-    syn match ddocIdentifier     "\$(\zs\h\w*\ze\_W*"    display conceal
-    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="   display contained
-    syn match ddocIdentifierDecl "\(^[+\|\*]\=\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*=" display contained
-    syn region ddocDecl   start="MACROS:\_s\+" end="\%$" transparent contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
-
-    "use html comment when fold method is marker
-    set commentstring=<!--%s-->
-
-    " highlight only ddoc Identifiers
-    hi! def link ddocIdentifier       Macro
-    hi! def link ddocIdentifierDecl   Macro
-    hi! def link ddocKeyword         Macro
-    finish
-else
-    "Ddoc inside comments
-    syn keyword ddocKeyword     MACROS                      contained
-    syn match ddocIdentifier     "\$(\zs\h\w*\ze\_W*"        display contained conceal containedin=@ddocComment
-    syn match ddocIdentifierDecl "^[+\|\*]\=\s*\h\w*\ze\s*=" display contained
-    syn match ddocIdentifierDecl "\(^[+\|\*]\=\S\{0}\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*="   display contained
-    syn region ddocDecl   start="^[+\|\*]\=\s*MACROS:\_s\+" end="\ze[+\|\*]\+/" transparent fold contained containedin=ddocDecl,ddocBlockComment,ddocNestedComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
-
-    "reset to default commentstring
-    set commentstring=/*%s*/
-    hi! def link ddocIdentifier       Macro
-    hi! def link ddocIdentifierDecl   Macro
-    hi! def link ddocKeyword         Macro
-endif
 
 
 " Keyword definitions

--- a/syntax/d.vim
+++ b/syntax/d.vim
@@ -48,10 +48,11 @@ if getline(1) =~ "^Ddoc"
     finish
 else
     "Ddoc inside comments
-    syn match ddocKeyword       "MACROS\ze\s*:"                  display containedin=@dComment
-    syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*"       display containedin=@dComment
-    syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*="      display containedin=@dComment
-    syn region ddocDecl   start="MACROS:\_s\+" end="\ze[+\|\*]\+/" transparent fold contained containedin=@dComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+    syn keyword ddocKeyword       MACROS                    display
+    syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*"  display contained containedin=@ddocComment
+    syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*=" display contained
+    
+    syn region ddocDecl   start="MACROS:\_s\+" end="\ze[+\|\*]\+/" transparent fold contained containedin=@ddocComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
 
     "reset to default commentstring
     set commentstring=/*%s*/
@@ -235,13 +236,18 @@ syn region dBlockComment	start="/\*"  end="\*/" contains=dBlockCommentString,dTo
 syn region dNestedComment	start="/+"  end="+/" contains=dNestedComment,dNestedCommentString,dTodo,@Spell fold
 syn match  dLineComment	"//.*" contains=dLineCommentString,dTodo,@Spell
 
+syn cluster ddocComment contains=ddocBlockComment,ddocNestedComment,ddocLineComment
+syn region ddocBlockComment  start="/\*\*" end="\*/" contains=dBlockCommentString,dTodo,dCommentStartError,@Spell fold
+syn region ddocNestedComment start="/++"   end="+/"  contains=ddocNestedComment,dNestedCommentString,dTodo,@Spell fold
+syn match  ddocLineComment   "///.*"                 contains=dLineCommentString,dTodo,@Spell
+
 hi link dLineCommentString	dBlockCommentString
 hi link dBlockCommentString	dString
 hi link dNestedCommentString	dString
 hi link dCommentStar		dBlockComment
 hi link dCommentPlus		dNestedComment
 
-syn cluster dTokens add=dBlockComment,dNestedComment,dLineComment
+syn cluster dTokens add=dBlockComment,dNestedComment,dLineComment,ddocBlockComment,ddocNestedComment,ddocLineComment
 
 " /+ +/ style comments and strings that span multiple lines can cause
 " problems. To play it safe, set minlines to a large number.
@@ -398,6 +404,9 @@ hi def link dType                Type
 hi def link dLineComment         Comment
 hi def link dBlockComment        Comment
 hi def link dNestedComment       Comment
+hi def link ddocLineComment      Comment
+hi def link ddocBlockComment     Comment
+hi def link ddocNestedComment    Comment
 hi def link dCommentError        Error
 hi def link dNestedCommentError  Error
 hi def link dCommentStartError   Error

--- a/syntax/d.vim
+++ b/syntax/d.vim
@@ -28,6 +28,38 @@ set cpo&vim
 " Set the current syntax to be known as d
 let b:current_syntax = "d"
 
+"Ddoc 
+if getline(1) =~ "^Ddoc"
+    "Ddoc File
+    syn match ddocKeyword "\%^Ddoc" display
+    syn keyword ddocKeyword MACROS contained
+    syn match ddocIdentifier "\$\s*(\s*\zs\h\w*\ze\_W*"     display
+    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="   display contained
+
+    syn region ddocDecl start="MACROS:\_s\+" end="\%$" transparent contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+
+    "use html comment when fold method is marker
+    set commentstring=<!--%s-->
+
+    " highlight only ddoc Identifiers
+    hi! def link ddocIdentifier       Macro
+    hi! def link ddocIdentifierDecl   Macro
+    hi! def link ddocKeyword          Macro
+    finish
+else
+    "Ddoc inside comments
+    syn match ddocKeyword "MACROS\ze\s*:"                             display containedin=@dComment
+    syn match ddocIdentifier "\$\s*(\s*\zs\h\w*\ze\_W*"       display containedin=@dComment
+    syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*=" display containedin=@dComment
+    syn region ddocDecl start="MACROS:\_s\+" end="[+\|\*]\+/$" transparent fold contained containedin=@dComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+
+    "reset to default commentstring
+    set commentstring=/*%s*/
+    hi! def link ddocIdentifier       Macro
+    hi! def link ddocIdentifierDecl   Macro
+    hi! def link ddocKeyword          Macro
+endif
+
 " Keyword definitions
 "
 syn keyword dExternal              contained import module

--- a/syntax/d.vim
+++ b/syntax/d.vim
@@ -31,12 +31,12 @@ let b:current_syntax = "d"
 "Ddoc 
 if getline(1) =~ "^Ddoc"
     "Ddoc File
-    syn match ddocKeyword       "\%^Ddoc"                  display
-    syn keyword ddocKeyword MACROS                         contained
-    syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*" display
-    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="      display contained
-
-    syn region ddocDecl start="MACROS:\_s\+" end="\%$" transparent contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+    syn match ddocKeyword       "\%^Ddoc"               display
+    syn keyword ddocKeyword     MACROS                  contained
+    syn match ddocIdentifier     "\$(\zs\h\w*\ze\_W*"    display conceal
+    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="   display contained
+    syn match ddocIdentifierDecl "\(^[+\|\*]\=\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*=" display contained
+    syn region ddocDecl   start="MACROS:\_s\+" end="\%$" transparent contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
 
     "use html comment when fold method is marker
     set commentstring=<!--%s-->
@@ -48,11 +48,11 @@ if getline(1) =~ "^Ddoc"
     finish
 else
     "Ddoc inside comments
-    syn keyword ddocKeyword       MACROS                    display
-    syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*"  display contained containedin=@ddocComment
-    syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*=" display contained
-    
-    syn region ddocDecl   start="MACROS:\_s\+" end="\ze[+\|\*]\+/" transparent fold contained containedin=@ddocComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+    syn keyword ddocKeyword     MACROS                      contained
+    syn match ddocIdentifier     "\$(\zs\h\w*\ze\_W*"        display contained conceal containedin=@ddocComment
+    syn match ddocIdentifierDecl "^[+\|\*]\=\s*\h\w*\ze\s*=" display contained
+    syn match ddocIdentifierDecl "\(^[+\|\*]\=\S\{0}\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*="   display contained
+    syn region ddocDecl   start="^[+\|\*]\=\s*MACROS:\_s\+" end="\ze[+\|\*]\+/" transparent fold contained containedin=ddocDecl,ddocBlockComment,ddocNestedComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
 
     "reset to default commentstring
     set commentstring=/*%s*/
@@ -60,6 +60,7 @@ else
     hi! def link ddocIdentifierDecl   Macro
     hi! def link ddocKeyword         Macro
 endif
+
 
 " Keyword definitions
 "

--- a/syntax/d.vim
+++ b/syntax/d.vim
@@ -31,10 +31,10 @@ let b:current_syntax = "d"
 "Ddoc 
 if getline(1) =~ "^Ddoc"
     "Ddoc File
-    syn match ddocKeyword "\%^Ddoc" display
-    syn keyword ddocKeyword MACROS contained
-    syn match ddocIdentifier "\$\s*(\s*\zs\h\w*\ze\_W*"     display
-    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="   display contained
+    syn match ddocKeyword       "\%^Ddoc"                  display
+    syn keyword ddocKeyword MACROS                         contained
+    syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*" display
+    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="      display contained
 
     syn region ddocDecl start="MACROS:\_s\+" end="\%$" transparent contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
 
@@ -44,20 +44,20 @@ if getline(1) =~ "^Ddoc"
     " highlight only ddoc Identifiers
     hi! def link ddocIdentifier       Macro
     hi! def link ddocIdentifierDecl   Macro
-    hi! def link ddocKeyword          Macro
+    hi! def link ddocKeyword         Macro
     finish
 else
     "Ddoc inside comments
-    syn match ddocKeyword "MACROS\ze\s*:"                             display containedin=@dComment
-    syn match ddocIdentifier "\$\s*(\s*\zs\h\w*\ze\_W*"       display containedin=@dComment
-    syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*=" display containedin=@dComment
-    syn region ddocDecl start="MACROS:\_s\+" end="[+\|\*]\+/$" transparent fold contained containedin=@dComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+    syn match ddocKeyword       "MACROS\ze\s*:"                  display containedin=@dComment
+    syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*"       display containedin=@dComment
+    syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*="      display containedin=@dComment
+    syn region ddocDecl   start="MACROS:\_s\+" end="[+\|\*]\+/$" transparent fold contained containedin=@dComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
 
     "reset to default commentstring
     set commentstring=/*%s*/
     hi! def link ddocIdentifier       Macro
     hi! def link ddocIdentifierDecl   Macro
-    hi! def link ddocKeyword          Macro
+    hi! def link ddocKeyword         Macro
 endif
 
 " Keyword definitions

--- a/syntax/d.vim
+++ b/syntax/d.vim
@@ -51,7 +51,7 @@ else
     syn match ddocKeyword       "MACROS\ze\s*:"                  display containedin=@dComment
     syn match ddocIdentifier     "\$\s*(\s*\zs\h\w*\ze\_W*"       display containedin=@dComment
     syn match ddocIdentifierDecl "^[+\*]*\s*\zs\h\w*\ze\s*="      display containedin=@dComment
-    syn region ddocDecl   start="MACROS:\_s\+" end="[+\|\*]\+/$" transparent fold contained containedin=@dComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+    syn region ddocDecl   start="MACROS:\_s\+" end="\ze[+\|\*]\+/" transparent fold contained containedin=@dComment contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
 
     "reset to default commentstring
     set commentstring=/*%s*/

--- a/syntax/ddoc.vim
+++ b/syntax/ddoc.vim
@@ -1,0 +1,82 @@
+if &filetype == "ddoc"
+    "ddoc file type
+    " Quit when a syntax file was already loaded
+    if exists("b:current_syntax")
+      finish
+    endif
+
+    " Support cpoptions
+    let s:cpo_save = &cpo
+    set cpo&vim
+
+    " Set the current syntax to be known as ddoc
+    let b:current_syntax = "ddoc"
+
+    syn match ddocIdentifier     "\$(\zs\h\w*\ze\_W*"    display conceal contained
+    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*=" display contained
+    syn region ddocDecl start="^\s*\zs\h\w*\ze\s*=" end="\ze\(\n\_^\s*\_$\|\n^\s*\h\w*\s*=\)" keepend transparent fold contains=ddocIdentifierDecl,ddocIdentifier
+
+    "use html comment when fold method is marker
+    set commentstring=<!--%s-->
+
+    hi! def link ddocIdentifier       Macro
+    hi! def link ddocIdentifierDecl   Macro
+
+    let &cpo = s:cpo_save
+    unlet s:cpo_save
+
+elseif &filetype == "d" && getline(1) =~ "^Ddoc"
+    "Ddoc inside .d File
+    " Quit when a syntax file was already loaded
+    if exists("b:current_syntax")
+      finish
+    endif
+
+    " Support cpoptions
+    let s:cpo_save = &cpo
+    set cpo&vim
+    " Set the current syntax to be known as ddoc
+    let b:current_syntax = "ddoc"
+
+    syn match ddocKeyword        "\%^Ddoc"               display
+    syn keyword ddocKeyword      MACROS                  contained
+    syn match ddocIdentifier     "\$(\zs\h\w*\ze\_W*"    display conceal
+    syn match ddocIdentifierDecl "^\s*\zs\h\w*\ze\s*="   display contained
+    "can slow down to much
+    "syn match ddocIdentifierDecl "\(^\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*=" display contained
+    syn region ddocDecl    start="^\s*MACROS:\_s\+" end="\%$" transparent contains=ddocKeyword,ddocIdentifierDecl,ddocIdentifier
+
+    "use html comment when fold method is marker
+    set commentstring=<!--%s-->
+
+    " highlight only ddoc Identifiers
+    hi! def link ddocIdentifier       Macro
+    hi! def link ddocIdentifierDecl   Macro
+    hi! def link ddocKeyword          Macro
+    let &cpo = s:cpo_save
+    unlet s:cpo_save
+    finish
+elseif &filetype == "d"
+    "Ddoc inside comments
+    syn keyword ddocKeyword            MACROS                      contained
+    syn match ddocIdentifier           "\$(\zs\h\w*\ze\_W*"        display contained conceal containedin=@ddocComment
+
+    syn match ddocIdentifierBlockDecl  "^\*\=\s*\h\w*\ze\s*=" display contained
+    "can slow down to much
+    "syn match ddocIdentifierBlockDecl "\(^*\=\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*="     display contained
+
+    syn region ddocBlockDecl start="^\*\=\s*\zsMACROS:\_s\+" end="\ze\*/" transparent fold contained containedin=ddocBlockComment  contains=ddocKeyword,ddocIdentifierBlockDecl,ddocIdentifier
+
+    syn match ddocIdentifierNestedDecl "^+\=\s*\h\w*\ze\s*="  display contained
+    "can slow down to much
+    "syn match ddocIdentifierNestedDecl "\(^+\=\s*MACROS:\s\+\)\@<=\zs\h\w*\ze\s*="     display contained
+
+    syn region ddocNestedDecl start="^+\=\s*\zsMACROS:\_s\+" end="\ze+/"  transparent fold contained containedin=ddocNestedComment contains=ddocKeyword,ddocIdentifierNestedDecl,ddocIdentifier
+
+    "reset to default commentstring
+    set commentstring=/*%s*/
+    hi! def link ddocIdentifier            Macro
+    hi! def link ddocIdentifierBlockDecl   Macro
+    hi! def link ddocIdentifierNestedDecl  Macro
+    hi! def link ddocKeyword               Macro
+endif


### PR DESCRIPTION
Added some highlighting to ddoc identifiers inside .d files beggining with Ddoc and inside comments from normal .d files.
Further it disables the normal d highlighting when the file begins with Ddoc and sets commentstring to a html comment so it wont show up when you use foldmarkers.